### PR TITLE
fix(locale): blank option if locale is unsupported

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -75,10 +75,9 @@ onBeforeMount(() => {
 import { i18n } from "./locales/schema"
 
 let urlParams = new URLSearchParams(window.location.search)
-if (urlParams.has("lang")) {
-  ;(i18n.global as any).locale = urlParams.get("lang") ?? "en-US"
-} else {
-  ;(i18n.global as any).locale = window.navigator.language ?? "en-US"
+const currentLocale = urlParams.get("lang") || window.navigator.language
+if (i18n.global.availableLocales.includes(currentLocale)) {
+  ;(i18n.global as any).locale = currentLocale
 }
 
 import { useI18n } from "vue-i18n"


### PR DESCRIPTION
If the current locale (whether from the browser or the URL param) isn't supported, the site correctly falls back to "en-US", but the respective selector shows as blank:

![ss](https://github.com/user-attachments/assets/7a4411ee-2089-4366-9334-d788890a8b45)

This happens because the site uses the current locale unconditionally, so long as it isn't blank. This PR fixes that by checking for support before using it.
