### PR TITLE
fix: don't show renovate on the contributors section

### DIFF
--- a/public/contributors.html
+++ b/public/contributors.html
@@ -98,7 +98,7 @@
   </body>
   <footer>
     <script type="text/javascript">
-      const ignoredContributors = ['github-actions[bot]', 'dependabot[bot]', 'pull[bot]'];
+      const ignoredContributors = ['github-actions[bot]', 'dependabot[bot]', 'pull[bot]', 'renovate[bot]'];
 
       /**
        * Lightly modified from:


### PR DESCRIPTION
Add Renovate to the list so it doesnt show up in the contributors section.