### PR TITLE
feat: randomize landing page's top dinosaur

### DIFF
--- a/src/components/scenes/SceneLanding.vue
+++ b/src/components/scenes/SceneLanding.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { onMounted, ref } from "vue"
 import SceneVisibilityChecker from "../common/SceneVisibilityChecker.vue"
-import { LangLandingBluefinImageURL } from "../../content"
+import { LangLandingBluefinImageURLs } from "../../content"
 import { i18n } from "../../locales/schema"
 import { useI18n } from "vue-i18n"
 import type { MessageSchema } from "../../locales/schema"
@@ -16,7 +16,12 @@ function scrollToPicker() {
     ?.scrollIntoView({ behavior: "smooth" })
 }
 
+function getRandomBluefinImage() {
+  return LangLandingBluefinImageURLs[Math.floor(Math.random() * LangLandingBluefinImageURLs.length)]
+}
+
 const isLoaded = ref(false)
+const LangLandingBluefinImageURL = getRandomBluefinImage()
 
 onMounted(() => {
   setTimeout(() => {

--- a/src/content.ts
+++ b/src/content.ts
@@ -1,5 +1,9 @@
 import { IconGithubCircle } from '@iconify-prerendered/vue-mdi'
 
+const characterImages = Object.keys(
+  import.meta.glob('/public/characters/*.webp')
+).map((v) => v.replace('/public', '.'))
+
 
 //
 //
@@ -8,7 +12,7 @@ import { IconGithubCircle } from '@iconify-prerendered/vue-mdi'
 export const LangLandingTag = 'Project'
 export const LangLandingTitle = 'Bluefin'
 export const LangLandingText = 'The next generation Linux workstation, designed for reliability, performance, and sustainability.'
-export const LangLandingBluefinImageURL = './characters/achillobator.webp'
+export const LangLandingBluefinImageURLs = characterImages
 
 //
 //


### PR DESCRIPTION
closes #191 

Solution:
- glob match for all `.webp` files under `public/characters` and store it in an array
- randomly select a file from that array on page load

Drop in or remove dinosaurs from `public/characters` and the next build will pick up on those changes.