### PR TITLE
Set angry as temporary header image

### DIFF
--- a/src/content.ts
+++ b/src/content.ts
@@ -12,7 +12,7 @@ export const LangLandingTag = "Project"
 export const LangLandingTitle = "Bluefin"
 export const LangLandingText =
   "The next generation Linux workstation, designed for reliability, performance, and sustainability."
-export const LangLandingBluefinImageURLs = characterImages
+export const LangLandingBluefinImageURLs = './characters/header/angry.webp'
 
 //
 //


### PR DESCRIPTION
Sets angry.webp as the header image until the raptor positioning problem situation is sorted