### PR TITLE
Modify margin and size of image-chooser elements

### DIFF
--- a/src/components/ImageChooser.vue
+++ b/src/components/ImageChooser.vue
@@ -641,11 +641,12 @@ onMounted(() => {
   justify-content: center;
   gap: 10px;
   padding: 0 20px;
-  font-size: 1.4rem;
+  font-size: 1.7rem;
   text-decoration: none;
   margin-bottom: 1rem;
   cursor: pointer;
   transition: all 0.3s ease;
+  margin: 24px;
 }
 
 .back-button:hover {
@@ -654,7 +655,7 @@ onMounted(() => {
 }
 
 .step-header h3 {
-  font-size: 1.5rem;
+  font-size: 1.7rem;
   margin: 0;
   color: white; /* Download the ISO text should be white - keeping this white */
 }

--- a/src/style/app/_scene.scss
+++ b/src/style/app/_scene.scss
@@ -77,7 +77,7 @@
 
     a {
       @include fonts.font(700);
-      color: var(--color-text-light) !important;
+      color: var(--color-blue-light) !important;
 
       &:hover {
         text-decoration: none;


### PR DESCRIPTION
This should add margins to the back button in the image chooser and improve the font size of the surrounding element. 