### PR TITLE
chore: address text overflow on small screens

### DIFF
--- a/src/style/overrides/_phone.scss
+++ b/src/style/overrides/_phone.scss
@@ -159,6 +159,20 @@
     }
   }
 
+  .btn-wrap {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 8px;
+  }
+
+  .btn {
+    width: 100%;
+    text-align: center;
+    font-size: 1.2rem;
+    padding: 0 12px;
+    justify-content: center;
+  }
+
   .container {
     width: 100%;
     max-width: 100%;
@@ -174,5 +188,15 @@
       max-width: 100%;
       padding: 0 32px;
     }
+  }
+}
+
+@media only screen and (max-width: 360px) {
+  .btn {
+    font-size: 1.1rem;
+    padding: 0 10px;
+    line-height: 32px;
+    height: 32px;
+    justify-content: center;
   }
 }

--- a/src/style/overrides/_tablet.scss
+++ b/src/style/overrides/_tablet.scss
@@ -145,6 +145,23 @@
     }
   }
 
+  @media only screen and (max-width: 640px) {
+    .btn-wrap {
+      flex-direction: column;
+      align-items: center;
+      gap: 8px;
+    }
+
+    .btn {
+      width: 100%;
+      max-width: 280px;
+      text-align: center;
+      font-size: 1.3rem;
+      padding: 0 16px;
+      justify-content: center;
+    }
+  }
+
   #scene-users {
     .container {
       display: block;


### PR DESCRIPTION
closes: #388 

Implemented a responsive button layout strategy with three breakpoints, Mobile (≤512px),  Tablet (≤640px), and Very Small Screens (≤360px).

<img width="1512" height="2510" alt="CleanShot 2025-09-01 at 15 47 11@2x" src="https://github.com/user-attachments/assets/fdc176f1-103f-4cb5-92f1-13647d1b1a2e" />
<img width="1512" height="2510" alt="CleanShot 2025-09-01 at 15 47 22@2x" src="https://github.com/user-attachments/assets/1f6dcbb7-5210-47a5-a72b-839c828573f3" />
<img width="1512" height="2510" alt="CleanShot 2025-09-01 at 15 47 34@2x" src="https://github.com/user-attachments/assets/d1a46b91-d00e-463f-9dc2-07074d2e2b76" />
