### PR TITLE
fix: properly scope SectionPicker anchor styling

### DIFF
--- a/src/components/sections/SectionPicker.vue
+++ b/src/components/sections/SectionPicker.vue
@@ -10,10 +10,10 @@ const { t } = useI18n<MessageSchema>({
 })
 </script>
 
-<style>
-#scene-picker a {
+<style scoped>
+p :deep(a) {
   @include font(700);
-  color: var(--color-text-light);
+  color: var(--color-blue-light);
 
   &:hover {
     text-decoration: none;


### PR DESCRIPTION
closes #380  🫡

Also fixes the anchor highlights at the bottom of this section:

<img width="671" height="245" alt="image" src="https://github.com/user-attachments/assets/e46a5d2e-d1e2-4cc4-a919-dbe0ae298abc" />
